### PR TITLE
#53 장바구니 아이템 삭제시 위젯 재빌드

### DIFF
--- a/lib/view/cart/cart_content.dart
+++ b/lib/view/cart/cart_content.dart
@@ -234,11 +234,11 @@ class _CartContentState extends State<_CartContent> {
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         GestureDetector(
-                            onTap: () {
-                              setState(() {
-                                CartDataSource()
+                            onTap: () async{
+                                debugPrint('2 = ${widget.cartData[1]}');
+                                await CartDataSource()
                                     .deleteCart(widget.cartData[1].cartId);
-                              });
+                                context.pushReplacement('/cart');
                             },
                             child: SvgPicture.asset("assets/icons/x.svg")),
                         SizedBox(height: 16.h),

--- a/lib/view/cart/cart_content.dart
+++ b/lib/view/cart/cart_content.dart
@@ -15,6 +15,8 @@ class _CartContent extends StatefulWidget {
 }
 
 class _CartContentState extends State<_CartContent> {
+  List<ReadCartResponse>? futureCart;
+
   int firstCartItemCount = 0;
   int secondCartItemCount = 0;
   int firstItemSubtotal = 0;
@@ -27,8 +29,9 @@ class _CartContentState extends State<_CartContent> {
   featchCartData() async {
     final storeData =
         await StoreDataSource().getStoreDetail(widget.cartData[0].storeId);
-
+    final cartDataSource = await CartDataSource().getCarts();
     setState(() {
+      futureCart = cartDataSource;
       firstCartItemCount = widget.cartData[0].cartItemCount;
       firstItemSubtotal += widget.cartData[0].subtotal.toInt();
       storeName = storeData.storeName;
@@ -117,13 +120,13 @@ class _CartContentState extends State<_CartContent> {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          CartDataSource()
-                              .deleteCart(widget.cartData[0].cartId);
-                        });
-                      },
-                      child: SvgPicture.asset("assets/icons/x.svg")),
+                    onTap: () async {
+                      await CartDataSource()
+                          .deleteCart(widget.cartData[0].cartId);
+                      context.pushReplacement('/cart');
+                    },
+                    child: SvgPicture.asset("assets/icons/x.svg"),
+                  ),
                   SizedBox(height: 16.h),
                   Row(
                     children: [
@@ -297,7 +300,7 @@ class _CartContentState extends State<_CartContent> {
                   ],
                 ),
               )
-            : SizedBox.shrink(),
+            : const SizedBox.shrink(),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 20.h, vertical: 25.w),
           child: Align(
@@ -365,10 +368,7 @@ class _CartContentState extends State<_CartContent> {
               TextField(
                 controller: reverationRequestEditingController,
                 onChanged: (value) {
-                  debugPrint('value = $value');
                   _CartContent.reservationRequest = value;
-                  debugPrint(
-                      'reservationRequest = ${_CartContent.reservationRequest}');
                 },
                 onTapOutside: (event) => FocusScope.of(context).unfocus(),
                 decoration: InputDecoration(
@@ -400,7 +400,7 @@ class _CartContentState extends State<_CartContent> {
                     },
                   ),
                 ],
-              )
+              ),
             ],
           ),
         ),

--- a/lib/view/cart/cart_page.dart
+++ b/lib/view/cart/cart_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mayo_flutter/dataSource/cart.dart';
 import 'package:mayo_flutter/dataSource/reservation.dart';
 import 'package:mayo_flutter/dataSource/store.dart';


### PR DESCRIPTION
## 📌 개요
- 장바구니 아이템 삭제시 아이템이 그대로 있는 문제를 장바구니 페이지를 라우팅하여 위젯을 재빌드해서 해결했습니다.

## 📸 구현 화면

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들