### PR TITLE
🎨 :: (72) 수량 텍스트 위치 조정

### DIFF
--- a/lib/view/product/product_bottom_sheet.dart
+++ b/lib/view/product/product_bottom_sheet.dart
@@ -197,9 +197,6 @@ class _ItemQuantityCounterState extends State<ItemQuantityCounter> {
             ),
             Row(
               children: [
-                Text("${ItemQuantityCounter.itemCount}",
-                    style: AppTextStyle.body1Bold),
-                SizedBox(width: 15.w),
                 GestureDetector(
                   onTap: () {
                     if (ItemQuantityCounter.itemCount > 1) {
@@ -210,7 +207,10 @@ class _ItemQuantityCounterState extends State<ItemQuantityCounter> {
                   },
                   child: SvgPicture.asset("assets/icons/minus.svg"),
                 ),
-                SizedBox(width: 20.w),
+                SizedBox(width: 15.w),
+                Text("${ItemQuantityCounter.itemCount}개",
+                    style: AppTextStyle.body1Bold),
+                SizedBox(width: 15.w),
                 GestureDetector(
                     onTap: () {
                       if (widget.itemQuantity > ItemQuantityCounter.itemCount) {


### PR DESCRIPTION
## 📌 개요
- 음식 정보 화면의 예약 모달에서 수량 텍스트의 위치를 (-) (+)버튼 사이로 위치를 조정했습니다.

## 📸 구현 화면
![image](https://github.com/user-attachments/assets/2497b477-1ed4-40d7-a8e1-43a9be20cb58)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들